### PR TITLE
[Omni] Publish npm package with trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,9 @@ jobs:
     name: Publish to npm
     needs: validate
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     defaults:
       run:
         working-directory: ts
@@ -62,7 +65,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "24"
           registry-url: "https://registry.npmjs.org"
           cache: "npm"
           cache-dependency-path: ts/package-lock.json
@@ -75,8 +78,6 @@ jobs:
 
       - name: Publish to npm
         run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   # Publish Python to PyPI
   publish-pypi:

--- a/.omni/71327bb3-greeting/memory.md
+++ b/.omni/71327bb3-greeting/memory.md
@@ -1,0 +1,24 @@
+# Workspace Context
+
+<!-- This file is auto-maintained. The Repositories section is refreshed -->
+<!-- by the system. The AI should maintain Environment & Key Discoveries. -->
+
+**Workspace root (absolute path):** `/home/workspaces/conversations/71327bb3-03fd-4337-b47f-6e35487a6803`
+
+## Repositories
+
+- **`capture-sdk/`** — Branch: `omni/71327bb3/capture-sdk`, Remote: `numbersprotocol/capture-sdk`
+  - Official SDKs for [Numbers Protocol](https://numbersprotocol.io/) Capture API. Register digital assets with blockchain-backed provenance.
+  - Has `CLAUDE.md` project instructions
+
+## Environment & Tools
+
+- Release workflow: `.github/workflows/release.yml` publishes npm package `@numbersprotocol/capture-sdk` from `ts/` and PyPI package from `python/` on `v*` tags.
+- npm publishing uses GitHub Actions trusted publishing/OIDC with Node.js 24; no `NPM_TOKEN` is required for npm publish.
+
+## Key Discoveries
+
+- TypeScript package `ts/package.json` repository URL is `git+https://github.com/numbersprotocol/capture-sdk.git` with `directory: "ts"`, matching npm trusted publisher requirements for the GitHub repo.
+
+---
+_Last system refresh: 2026-05-04 08:48 UTC_


### PR DESCRIPTION
## Summary
This updates `.github/workflows/release.yml` to publish the npm package using npm trusted publishing instead of the `NPM_TOKEN` repository secret. The publish job now requests a GitHub OIDC token so npm can verify the workflow identity, avoiding the need to rotate 90-day access tokens.

## Changes
- Add `contents: read` and `id-token: write` permissions to the `publish` job in `.github/workflows/release.yml`.
- Remove token-based npm authentication from the release workflow.
- Keep the existing validation and publish flow while switching the npm authentication mechanism to trusted publishing.

2 files changed, +28 additions, -3 deletions

<details>
<summary>File changes</summary>

```
.github/workflows/release.yml     |  7 ++++---
 .omni/71327bb3-greeting/memory.md | 24 ++++++++++++++++++++++++
```
</details>

---
Generated by Olga Shen with [Omni](https://omniai.one/)